### PR TITLE
Remove indent check from `.jshintrc`

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,6 @@
   "eqeqeq": true,
   "forin": true,
   "immed": true,
-  "indent": 2,
   "latedef": true,
   "newcap": true,
   "noarg": true,


### PR DESCRIPTION
It's already in `.jscsrc`.
